### PR TITLE
Upgrade nose to nose2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,4 @@ python:
 # command to install dependencies
 install: "pip install -r requirements.txt"
 # command to run tests
-script:
-  - pytest
+script: "nose2 -v"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,3 @@ python:
   - "pypy3"
 # command to install dependencies
 install: "pip install -r requirements.txt"
-# command to run tests
-script: nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ python:
   - "pypy3"
 # command to install dependencies
 install: "pip install -r requirements.txt"
+# command to run tests
+script:
+  - pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ praw==7.1.0
 requests==2.24.0
 six==1.15.0
 update-checker==0.18.0
+nose2==0.10.0


### PR DESCRIPTION
Nose does not work in python nightly so causes Travis to fail.
As nose is depreciated and we don't run any tests we should be able to simply change to nose2 without any issues.
This should fix build issues with #1.