### PR TITLE
fix(requirements.txt): bump praw version to 7.8.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 decorator==5.1.1
 future==0.18.3
-praw==7.5.0
+praw==7.8.1
 requests==2.32.2
 six==1.16.0
 update-checker==0.18.0


### PR DESCRIPTION
This is a small (one-liner) PR to remove the warning every time the script is executed.

The python script works on my setup with this new version as there does not seem to be any breaking changes but I would be glad if you could test on your side as well.

Thanks a lot